### PR TITLE
Use org NuGet publish secret

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -91,7 +91,7 @@ jobs:
         run: |                             
           $nupkgs = Get-ChildItem ".\${{ env.GITHUB_WORKSPACE }}\nupkgs" -Filter *.nupkg | Select-Object -ExpandProperty FullName          
           $nupkgs | ForEach-Object {
-            dotnet nuget push $_ --source nuget.org --api-key ${{ secrets.PETERSUNDE_NUGET_ORG_API_KEY }}  
+            dotnet nuget push $_ --source nuget.org --api-key ${{ secrets.FINTER_NUGET_ORG_API_KEY }}
             if($LASTEXITCODE -ne 0) {
                Write-Error "Error uploading nupkg: $_. Exit code: $LASTEXITCODE"
             }


### PR DESCRIPTION
## Summary
- replace the personal-named NuGet.org publish secret with `FINTER_NUGET_ORG_API_KEY`
- keep the package publish workflow behavior unchanged

Tracking: fintermobilityas/youpark.no#12240

## Validation
- `git diff --check`
- GitHub Actions must pass before merge

## Notes
- No package publish workflow was triggered.
- The new org secret is selected to `surge` and `mongomigrations.core` only.